### PR TITLE
Add human_readable_renderer.py + render DenseNet/SubCell HTML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,20 @@ endif
 	$(RUN) python scripts/render_evaluation_html.py --input-glob '$(EVAL_JSONS)' --output $(BADGE_DIR) --badge --title "Model Card quality badges"
 
 # =========================================================================
+# Human-readable HTML render of a Model Card YAML
+# =========================================================================
+# Writes <input>.html next to the YAML by default. Pass --output for custom.
+#   make render-card MC_FILE=data/model_cards_assistant/foo_model_card.yaml
+#   make render-card MC_FILE='data/model_cards_assistant/*.yaml'  # globs work
+render-card:
+ifndef MC_FILE
+	$(error MC_FILE is required: make render-card MC_FILE=path/to/card.yaml)
+endif
+	$(RUN) python src/html/human_readable_renderer.py $(MC_FILE)
+
+.PHONY: render-card
+
+# =========================================================================
 # Portfolio: regenerate dashboards + badges from existing eval JSONs
 # =========================================================================
 # Re-renders portfolio.html, portfolio_compare.html, and the badges/ dir

--- a/data/model_cards_assistant/densenet121_tv_in1k_model_card.html
+++ b/data/model_cards_assistant/densenet121_tv_in1k_model_card.html
@@ -1,0 +1,117 @@
+<!doctype html><html><head><meta charset="utf-8"><title>DenseNet-121 (timm/densenet121.tv_in1k) — Model Card</title><style>
+:root {
+  --bg: #fafafa; --card: #fff; --border: #e5e5e5;
+  --text: #111; --muted: #6b7280; --accent: #2563eb;
+  --good: #16a34a; --warn: #ca8a04; --bad: #dc2626;
+}
+* { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg); color: var(--text);
+  margin: 0; padding: 2rem 1.5rem; line-height: 1.5;
+}
+header, main, footer { max-width: 980px; margin: 0 auto; }
+header { padding-bottom: 1.25rem; border-bottom: 1px solid var(--border); margin-bottom: 1.5rem; }
+h1 { font-size: 1.85rem; margin: 0 0 .35rem; }
+h2 {
+  font-size: 1.2rem; margin: 1.5rem 0 .6rem;
+  padding-bottom: .3rem; border-bottom: 1px solid var(--border);
+}
+h3 { font-size: 1rem; margin: 1rem 0 .35rem; color: var(--accent); }
+.short { color: var(--muted); font-size: 1rem; margin: 0 0 .75rem; }
+.meta-row { color: var(--muted); font-size: .85rem; }
+.meta-row span + span::before { content: " · "; padding: 0 .2rem; }
+.badge-row { margin: .75rem 0; display: flex; flex-wrap: wrap; gap: .3rem; }
+.badge-row img { height: 20px; }
+
+.card {
+  background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+  padding: 1rem 1.25rem; margin: 1rem 0;
+}
+.card h2 { margin-top: 0; border-bottom: none; }
+
+dl.kv { margin: 0; }
+dl.kv > div { display: grid; grid-template-columns: 200px 1fr; gap: .5rem 1rem; padding: .35rem 0; border-top: 1px solid var(--border); }
+dl.kv > div:first-child { border-top: 0; }
+dl.kv dt { color: var(--muted); font-weight: 500; font-size: .9rem; }
+dl.kv dd { margin: 0; word-break: break-word; }
+dl.kv code { background: #f3f4f6; padding: .05rem .3rem; border-radius: 3px; font-size: .85rem; }
+
+.chip-row { display: flex; flex-wrap: wrap; gap: .35rem; }
+.chip { background: #eef2ff; color: #3730a3; padding: .15rem .55rem; border-radius: 999px; font-size: .8rem; }
+
+ul.bullet { padding-left: 1.2rem; margin: .3rem 0; }
+ul.bullet li { margin: .2rem 0; }
+
+.contrib-row { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem 1rem; padding: .35rem 0; border-top: 1px solid var(--border); font-size: .9rem; }
+.contrib-row:first-child { border-top: 0; }
+.contrib-role { display: inline-block; background: #fef3c7; color: #92400e; padding: .05rem .4rem; border-radius: 4px; font-size: .75rem; margin-left: .35rem; }
+
+table.metrics { width: 100%; border-collapse: collapse; margin: .3rem 0; font-size: .9rem; }
+table.metrics th, table.metrics td {
+  padding: .4rem .75rem; border-top: 1px solid var(--border); text-align: left; vertical-align: top;
+}
+table.metrics th { background: #f9fafb; font-weight: 600; }
+table.metrics td.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+pre {
+  background: #f3f4f6; padding: .75rem 1rem; border-radius: 6px;
+  overflow-x: auto; font-size: .85rem;
+}
+pre code { background: transparent; padding: 0; }
+
+.markdown p { margin: .4rem 0; }
+.markdown code { background: #f3f4f6; padding: .05rem .3rem; border-radius: 3px; font-size: .9rem; }
+
+footer { color: var(--muted); font-size: .8rem; text-align: center; margin: 2rem 0 0; }
+.tag-license { background: #d1fae5; color: #065f46; padding: .1rem .45rem; border-radius: 4px; font-size: .8rem; }
+.bias-block { background: #fff7ed; border-left: 3px solid #f97316; padding: .5rem .75rem; margin: .35rem 0; border-radius: 0 4px 4px 0; font-size: .9rem; }
+</style></head><body><header><h1>DenseNet-121 (timm/densenet121.tv_in1k)</h1><p class=short>DenseNet image classification model trained on ImageNet-1k (original torchvision weights, distributed via timm).</p><div class="meta-row"><span><code>image-classification</code></span><span>PyTorch torch&gt;=1.13</span><span>library: <code>timm</code></span><span>base: <code>torchvision/densenet121</code></span></div><div class="chip-row" style="margin-top:.4rem;"><span class="chip">image-classification</span> <span class="chip">densenet</span> <span class="chip">imagenet</span> <span class="chip">imagenet-1k</span> <span class="chip">computer-vision</span> <span class="chip">timm</span> <span class="chip">feature-extraction</span> <span class="chip">transfer-learning</span></div><div class="badge-row"><img src="../evaluation/badges/densenet121_tv_in1k_model_card_rubric10_hybrid.svg" alt="densenet121_tv_in1k_model_card_rubric10_hybrid"> <img src="../evaluation/badges/densenet121_tv_in1k_model_card_rubric10_llm.svg" alt="densenet121_tv_in1k_model_card_rubric10_llm"> <img src="../evaluation/badges/densenet121_tv_in1k_model_card_rubric10_semantic_llm.svg" alt="densenet121_tv_in1k_model_card_rubric10_semantic_llm"> <img src="../evaluation/badges/densenet121_tv_in1k_model_card_rubric20_hybrid.svg" alt="densenet121_tv_in1k_model_card_rubric20_hybrid"> <img src="../evaluation/badges/densenet121_tv_in1k_model_card_rubric20_llm.svg" alt="densenet121_tv_in1k_model_card_rubric20_llm"> <img src="../evaluation/badges/densenet121_tv_in1k_model_card_rubric20_semantic_llm.svg" alt="densenet121_tv_in1k_model_card_rubric20_semantic_llm"></div><div class="meta-row" style="margin-top:.5rem;">Source YAML: <code>data/model_cards_assistant/densenet121_tv_in1k_model_card.yaml</code></div></header><main><section class="card"><h2>Model Details</h2><p><strong>tv_in1k</strong> <span class="meta-row">2017-08-25</span></p><h3>Change description</h3><div class="markdown"><p>Original torchvision DenseNet-121 ImageNet-1k weights, repackaged under timm&#x27;s
+`timm/densenet121.tv_in1k` HuggingFace Hub identifier.
+</p></div><h3>Overview</h3><div class="markdown"><p>DenseNet-121 is a densely connected convolutional network (Huang et al., CVPR 2017) where every layer<br>receives feature maps from all preceding layers and passes its own feature maps to all subsequent layers.<br>This dense connectivity pattern alleviates the vanishing-gradient problem, strengthens feature<br>propagation, encourages feature reuse, and substantially reduces the parameter count compared to<br>traditional CNNs of similar depth.<br><br>This particular checkpoint (`timm/densenet121.tv_in1k`) is the original torchvision weights repackaged<br>under the timm (PyTorch Image Models) ecosystem so it can be loaded with timm&#x27;s unified model API.<br>It is trained on the ImageNet-1k classification benchmark (1.28M training images across 1000 classes).<br></p></div><h3>Documentation</h3><pre>## Model Architecture
+- Backbone: DenseNet-121 with four dense blocks
+- Growth rate: 32 (feature maps added per layer)
+- Total parameters: ~8.0M
+- Compute: 2.9 GMACs at 224x224
+- Activations: 6.9M
+- Input resolution: 224 x 224
+
+## Usage with timm
+```python
+import timm
+model = timm.create_model(&quot;densenet121.tv_in1k&quot;, pretrained=True)
+model.eval()
+```
+
+The model also exposes feature-extraction modes (forward_features, forward_head) for use as a
+backbone in detection, segmentation, or transfer learning pipelines.
+
+## Citation
+See model_details.citations and model_details.references.
+</pre><h3>Owners / Contributors</h3><div class="contrib-row"><span><strong>Gao Huang</strong> <span class="contrib-role">developed_by</span></span><span>Cornell University</span></div><div class="contrib-row"><span><strong>Zhuang Liu</strong> <span class="contrib-role">developed_by</span></span><span>Tsinghua University</span></div><div class="contrib-row"><span><strong>Laurens van der Maaten</strong> <span class="contrib-role">developed_by</span></span><span>Facebook AI Research</span></div><div class="contrib-row"><span><strong>Kilian Q. Weinberger</strong> <span class="contrib-role">developed_by</span></span><span>Cornell University</span></div><div class="contrib-row"><span><strong>PyTorch Vision Team</strong> <span class="contrib-role">contributed_by</span></span><span>Meta</span></div><div class="contrib-row"><span><strong>Ross Wightman (timm)</strong> <span class="contrib-role">contributed_by</span></span><span>Hugging Face</span></div><h3>Licenses</h3><div class="chip-row"><span class="tag-license"><a href="https://www.apache.org/licenses/LICENSE-2.0">Apache-2.0</a></span></div><h3>Citations</h3><p><span class="chip">IEEE</span> <span class="markdown">G. Huang, Z. Liu, L. van der Maaten, and K. Q. Weinberger, &quot;Densely connected convolutional networks,&quot;
+in Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR), 2017, pp. 4700–4708.
+</span></p><h3>References</h3><ul class="bullet"><li><a href="https://arxiv.org/abs/1608.06993">https://arxiv.org/abs/1608.06993</a></li><li><a href="https://huggingface.co/timm/densenet121.tv_in1k">https://huggingface.co/timm/densenet121.tv_in1k</a></li><li><a href="https://github.com/huggingface/pytorch-image-models">https://github.com/huggingface/pytorch-image-models</a></li><li><a href="https://pytorch.org/vision/main/models/densenet.html">https://pytorch.org/vision/main/models/densenet.html</a></li></ul><h3>Path</h3><a href="https://huggingface.co/timm/densenet121.tv_in1k">https://huggingface.co/timm/densenet121.tv_in1k</a></section><section class="card"><h2>Model Parameters</h2><h3>Architecture</h3><div class="markdown"><p>DenseNet-121 architecture with 4 dense blocks (each with growth rate 32) interleaved with<br>transition layers (1x1 conv + 2x2 average pool). Total ~8.0M parameters, ~2.9 GMACs at 224x224.<br>Final 1000-way classifier head trained on ImageNet-1k.<br></p></div><h3>Input format</h3><p>RGB images, 224x224, normalized with ImageNet mean/std</p><dl class="kv"><div><dt><code>shape</code></dt><dd>[B, 3, 224, 224]</dd></div><div><dt><code>dtype</code></dt><dd>float32</dd></div><div><dt><code>normalization</code></dt><dd>mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]</dd></div></dl><h3>Output format</h3><p>1000-way classification logits</p><dl class="kv"><div><dt><code>shape</code></dt><dd>[B, 1000]</dd></div><div><dt><code>interpretation</code></dt><dd>raw logits over ImageNet-1k classes; apply softmax for probabilities</dd></div></dl><h3>Datasets</h3><div style="margin-bottom: .5rem;"><strong><a href="https://www.image-net.org/">ImageNet-1k (ILSVRC2012)</a></strong><p>1,281,167 training images and 50,000 validation images across 1000 object categories.
+Used for both training and ImageNet-1k accuracy evaluation.
+</p><div class="meta-row"><strong>Sensitive data:</strong> No PII in labels; some person-class images contain incidental faces</div><div class="bias-block"><strong>bias_input:</strong> ImageNet-1k has documented geographic and demographic skew (Western-centric, English-speaking
+contributors); some classes overlap with person/identity categories. See Crawford &amp; Paglen 2019,
+Yang et al. 2020 for analyses.
+</div></div></section><section class="card"><h2>Quantitative Analysis</h2><table class="metrics"><thead><tr><th>Metric</th><th>Slice</th><th class="num">Value</th><th class="num">Unit</th><th class="num">CI</th></tr></thead><tbody><tr><td>top-1 accuracy</td><td>ImageNet-1k validation (reference torchvision)</td><td class="num">74.4</td><td class="num">%</td><td class="num"></td></tr><tr><td>top-5 accuracy</td><td>ImageNet-1k validation (reference torchvision)</td><td class="num">91.9</td><td class="num">%</td><td class="num"></td></tr><tr><td>parameters</td><td>model size</td><td class="num">8.0</td><td class="num">M params</td><td class="num"></td></tr><tr><td>GMACs</td><td>224x224 input</td><td class="num">2.9</td><td class="num">GMACs</td><td class="num"></td></tr></tbody></table></section><section class="card"><h2>Considerations</h2><h3>Intended users</h3><ul class="bullet"><li><strong>ML researchers and engineers using DenseNet-121 as a baseline for image-classification
+benchmarks, a feature backbone for transfer learning, or a building block in detection
+and segmentation pipelines.
+</strong></li></ul><h3>Use cases</h3><ul class="bullet"><li><strong>ImageNet-1k image classification baseline</strong></li><li><strong>Transfer learning backbone for downstream computer-vision tasks</strong></li><li><strong>Feature extraction (forward_features) for use in detection / segmentation</strong></li><li><strong>Educational reference implementation of densely-connected architectures</strong></li></ul><h3>Limitations</h3><ul class="bullet"><li><strong>Trained on ImageNet-1k only; out-of-distribution performance on non-ImageNet domains
+(medical imaging, satellite imagery, microscopy) is unknown without further fine-tuning.
+</strong></li><li><strong>Reflects biases known to be present in the ImageNet-1k label space: skewed object-class
+distribution, Western-centric representation, label noise on visually-similar classes.
+</strong></li><li><strong>Original 2017-era torchvision training recipe; modern recipes (RandAugment, MixUp,
+Knowledge Distillation, longer training) can substantially raise these baselines.
+</strong></li></ul><h3>Tradeoffs</h3><ul class="bullet"><li><strong>Compared to ResNet-50 (25M params), DenseNet-121 reaches similar accuracy with ~1/3 the
+parameters but slower wall-clock inference due to memory-bandwidth-heavy dense connections.
+</strong></li></ul><h3>Ethical considerations</h3><ul class="bullet"><li><strong>ImageNet representation bias</strong><br><em>Mitigation:</em> Downstream deployers should audit the model on their target population and consult
+the ImageNet Roulette / Buolamwini-style analyses on class distribution before
+deploying for use cases that touch person classes.
+</li></ul><h3>Out-of-scope uses</h3><ul class="bullet"><li><strong>Face recognition / identification</strong></li><li><strong>Demographic classification (age, gender, ethnicity)</strong></li><li><strong>Surveillance applications</strong></li><li><strong>Clinical / medical diagnosis without dedicated retraining and regulatory clearance</strong></li></ul></section><section class="card"><h2>Bias Disclosure</h2><div class="bias-block"><strong>bias_model:</strong> Inherits the geographic / demographic skew of its training data. No fairness audit was
+performed by the original DenseNet authors. Users should run their own slice-level evaluation
+on relevant subpopulations before deployment.
+</div><div class="bias-block"><strong>bias_output:</strong> Logit calibration follows the ImageNet-1k class prior; rare classes may be under-predicted.
+Not calibrated for any specific downstream task.
+</div></section></main><footer>Rendered 2026-06-24T19:47:30.397503+00:00 from <code>data/model_cards_assistant/densenet121_tv_in1k_model_card.yaml</code></footer></body></html>

--- a/data/model_cards_assistant/subcell_saprot_650m_model_card.html
+++ b/data/model_cards_assistant/subcell_saprot_650m_model_card.html
@@ -1,0 +1,121 @@
+<!doctype html><html><head><meta charset="utf-8"><title>SaProtHub SubCell Localization 650M (LoRA-fine-tuned SaProt) — Model Card</title><style>
+:root {
+  --bg: #fafafa; --card: #fff; --border: #e5e5e5;
+  --text: #111; --muted: #6b7280; --accent: #2563eb;
+  --good: #16a34a; --warn: #ca8a04; --bad: #dc2626;
+}
+* { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg); color: var(--text);
+  margin: 0; padding: 2rem 1.5rem; line-height: 1.5;
+}
+header, main, footer { max-width: 980px; margin: 0 auto; }
+header { padding-bottom: 1.25rem; border-bottom: 1px solid var(--border); margin-bottom: 1.5rem; }
+h1 { font-size: 1.85rem; margin: 0 0 .35rem; }
+h2 {
+  font-size: 1.2rem; margin: 1.5rem 0 .6rem;
+  padding-bottom: .3rem; border-bottom: 1px solid var(--border);
+}
+h3 { font-size: 1rem; margin: 1rem 0 .35rem; color: var(--accent); }
+.short { color: var(--muted); font-size: 1rem; margin: 0 0 .75rem; }
+.meta-row { color: var(--muted); font-size: .85rem; }
+.meta-row span + span::before { content: " · "; padding: 0 .2rem; }
+.badge-row { margin: .75rem 0; display: flex; flex-wrap: wrap; gap: .3rem; }
+.badge-row img { height: 20px; }
+
+.card {
+  background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+  padding: 1rem 1.25rem; margin: 1rem 0;
+}
+.card h2 { margin-top: 0; border-bottom: none; }
+
+dl.kv { margin: 0; }
+dl.kv > div { display: grid; grid-template-columns: 200px 1fr; gap: .5rem 1rem; padding: .35rem 0; border-top: 1px solid var(--border); }
+dl.kv > div:first-child { border-top: 0; }
+dl.kv dt { color: var(--muted); font-weight: 500; font-size: .9rem; }
+dl.kv dd { margin: 0; word-break: break-word; }
+dl.kv code { background: #f3f4f6; padding: .05rem .3rem; border-radius: 3px; font-size: .85rem; }
+
+.chip-row { display: flex; flex-wrap: wrap; gap: .35rem; }
+.chip { background: #eef2ff; color: #3730a3; padding: .15rem .55rem; border-radius: 999px; font-size: .8rem; }
+
+ul.bullet { padding-left: 1.2rem; margin: .3rem 0; }
+ul.bullet li { margin: .2rem 0; }
+
+.contrib-row { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem 1rem; padding: .35rem 0; border-top: 1px solid var(--border); font-size: .9rem; }
+.contrib-row:first-child { border-top: 0; }
+.contrib-role { display: inline-block; background: #fef3c7; color: #92400e; padding: .05rem .4rem; border-radius: 4px; font-size: .75rem; margin-left: .35rem; }
+
+table.metrics { width: 100%; border-collapse: collapse; margin: .3rem 0; font-size: .9rem; }
+table.metrics th, table.metrics td {
+  padding: .4rem .75rem; border-top: 1px solid var(--border); text-align: left; vertical-align: top;
+}
+table.metrics th { background: #f9fafb; font-weight: 600; }
+table.metrics td.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+pre {
+  background: #f3f4f6; padding: .75rem 1rem; border-radius: 6px;
+  overflow-x: auto; font-size: .85rem;
+}
+pre code { background: transparent; padding: 0; }
+
+.markdown p { margin: .4rem 0; }
+.markdown code { background: #f3f4f6; padding: .05rem .3rem; border-radius: 3px; font-size: .9rem; }
+
+footer { color: var(--muted); font-size: .8rem; text-align: center; margin: 2rem 0 0; }
+.tag-license { background: #d1fae5; color: #065f46; padding: .1rem .45rem; border-radius: 4px; font-size: .8rem; }
+.bias-block { background: #fff7ed; border-left: 3px solid #f97316; padding: .5rem .75rem; margin: .35rem 0; border-radius: 0 4px 4px 0; font-size: .9rem; }
+</style></head><body><header><h1>SaProtHub SubCell Localization 650M (LoRA-fine-tuned SaProt)</h1><p class=short>Protein-level classifier predicting subcellular localization across ten cellular compartments using a LoRA-fine-tuned 650M-parameter structure-aware protein language model.</p><div class="meta-row"><span><code>text-classification</code></span><span>PyTorch torch&gt;=2.0</span><span>library: <code>transformers</code></span><span>base: <code>westlake-repl/SaProt_650M_AF2</code></span></div><div class="chip-row" style="margin-top:.4rem;"><span class="chip">protein-language-model</span> <span class="chip">subcellular-localization</span> <span class="chip">bioinformatics</span> <span class="chip">protein-classification</span> <span class="chip">saprot</span> <span class="chip">lora</span> <span class="chip">deeploc</span> <span class="chip">structure-aware</span></div><div class="badge-row"><img src="../evaluation/badges/subcell_saprot_650m_model_card_rubric10_hybrid.svg" alt="subcell_saprot_650m_model_card_rubric10_hybrid"> <img src="../evaluation/badges/subcell_saprot_650m_model_card_rubric10_llm.svg" alt="subcell_saprot_650m_model_card_rubric10_llm"> <img src="../evaluation/badges/subcell_saprot_650m_model_card_rubric10_semantic_llm.svg" alt="subcell_saprot_650m_model_card_rubric10_semantic_llm"> <img src="../evaluation/badges/subcell_saprot_650m_model_card_rubric20_hybrid.svg" alt="subcell_saprot_650m_model_card_rubric20_hybrid"> <img src="../evaluation/badges/subcell_saprot_650m_model_card_rubric20_llm.svg" alt="subcell_saprot_650m_model_card_rubric20_llm"> <img src="../evaluation/badges/subcell_saprot_650m_model_card_rubric20_semantic_llm.svg" alt="subcell_saprot_650m_model_card_rubric20_semantic_llm"></div><div class="meta-row" style="margin-top:.5rem;">Source YAML: <code>data/model_cards_assistant/subcell_saprot_650m_model_card.yaml</code></div></header><main><section class="card"><h2>Model Details</h2><p><strong>1.0</strong> <span class="meta-row">2024-08-01</span></p><h3>Change description</h3><div class="markdown"><p>Initial release of the LoRA fine-tune on the DeepLoc subcellular-localization
+training split using AdamW for 100 epochs.
+</p></div><h3>Overview</h3><div class="markdown"><p>This model classifies protein sequences into one of ten subcellular localization classes:<br>nucleus, cytoplasm, extracellular space, mitochondrion, cell membrane, endoplasmic reticulum,<br>plastid, Golgi apparatus, lysosome/vacuole, and peroxisome.<br><br>It is a LoRA (Low-Rank Adaptation) fine-tune of westlake-repl/SaProt_650M_AF2 — a 650M-parameter<br>structure-aware protein language model that incorporates AlphaFold2 structural tokens alongside<br>the amino-acid sequence. LoRA is applied to the query/key/value attention projections and the<br>feedforward dense layers, with a small classifier head added on top.<br><br>The model achieves 85.75% test-set accuracy on the DeepLoc subcellular localization benchmark.<br></p></div><h3>Documentation</h3><pre>## Architecture
+- Base model: westlake-repl/SaProt_650M_AF2 (650M parameters)
+- Adaptation: LoRA on attention projections (Q/K/V) + FFN dense layers
+- LoRA rank: 16, alpha: 32, dropout: 0
+- Classifier head: 10-way over subcellular localization classes
+- Inherited input: structure-aware (SA) sequence — amino-acid sequence + AlphaFold2 structure tokens
+
+## Usage
+```python
+from saprot_hub import load_model
+model = load_model(&quot;SaProtHub/Model-Subcellular_Localization-650M&quot;)
+# Input: SA-sequence (protein sequence with structure annotations)
+pred = model.predict(sa_sequence)  # 0-9 class label
+```
+
+## Training Configuration
+- Optimizer: AdamW (β1=0.9, β2=0.98, weight_decay=0.01)
+- Learning rate: 5e-4
+- Epochs: 100
+- Batch size: 64
+- Precision: 16-bit mixed
+</pre><h3>Owners / Contributors</h3><div class="contrib-row"><span><strong>SaProtHub maintainers</strong> <span class="contrib-role">developed_by</span></span><span>Westlake Representation Learning Lab</span></div><div class="contrib-row"><span><strong>Westlake-repl team (base SaProt)</strong> <span class="contrib-role">contributed_by</span></span><span>Westlake University</span></div><h3>Licenses</h3><div class="chip-row"><span class="tag-license"><a href="https://opensource.org/licenses/MIT">MIT</a></span></div><h3>Citations</h3><p><span class="chip">IEEE</span> <span class="markdown">SaProtHub, &quot;SubCellular Localization 650M (LoRA fine-tune of SaProt_650M_AF2),&quot; HuggingFace Hub, 2024.
+[Online]. Available: https://huggingface.co/SaProtHub/Model-Subcellular_Localization-650M
+</span></p><p><span class="chip">IEEE</span> <span class="markdown">J. Su et al., &quot;SaProt: Protein Language Modeling with Structure-aware Vocabulary,&quot; in ICLR, 2024.
+</span></p><h3>References</h3><ul class="bullet"><li><a href="https://huggingface.co/SaProtHub/Model-Subcellular_Localization-650M">https://huggingface.co/SaProtHub/Model-Subcellular_Localization-650M</a></li><li><a href="https://huggingface.co/westlake-repl/SaProt_650M_AF2">https://huggingface.co/westlake-repl/SaProt_650M_AF2</a></li><li><a href="https://github.com/westlake-repl/SaProt">https://github.com/westlake-repl/SaProt</a></li><li><a href="https://www.uniprot.org/help/subcellular_location">https://www.uniprot.org/help/subcellular_location</a></li><li><a href="https://services.healthtech.dtu.dk/services/DeepLoc-2.0/">https://services.healthtech.dtu.dk/services/DeepLoc-2.0/</a></li></ul><h3>Path</h3><a href="https://huggingface.co/SaProtHub/Model-Subcellular_Localization-650M">https://huggingface.co/SaProtHub/Model-Subcellular_Localization-650M</a></section><section class="card"><h2>Model Parameters</h2><h3>Architecture</h3><div class="markdown"><p>Transformer-based protein language model: 650M-parameter SaProt_650M_AF2 base (ESM-style encoder<br>augmented with structure-aware vocabulary from AlphaFold2 Foldseek tokens). Fine-tuning uses<br>LoRA (rank 16, alpha 32, dropout 0) targeting attention query/key/value projections and the<br>feedforward dense layers (intermediate.dense and output.dense). A linear classifier head<br>projects pooled representations to 10 subcellular-localization classes.<br></p></div><h3>Input format</h3><p>Structure-aware (SA) protein sequence — amino-acid sequence interleaved with AlphaFold2 Foldseek structural tokens</p><dl class="kv"><div><dt><code>type</code></dt><dd>string</dd></div><div><dt><code>encoding</code></dt><dd>SA-vocabulary (amino acids + structural tokens)</dd></div><div><dt><code>max_length</code></dt><dd>model-dependent (typically 1024 SA-tokens)</dd></div></dl><h3>Output format</h3><p>Classification label (integer 0-9) corresponding to one of ten subcellular localization classes</p><dl class="kv"><div><dt><code>shape</code></dt><dd>[B, 10]</dd></div><div><dt><code>interpretation</code></dt><dd>raw logits over {nucleus, cytoplasm, extracellular, mitochondrion, cell_membrane, endoplasmic_reticulum, plastid, golgi, lysosome_vacuole, peroxisome}</dd></div></dl><h3>Datasets</h3><div style="margin-bottom: .5rem;"><strong><a href="https://huggingface.co/datasets/SaProtHub/Dataset-Subcellular_Localization-DeepLoc">DeepLoc subcellular localization dataset (SaProtHub mirror)</a></strong><p>DeepLoc 2.0 benchmark: SwissProt proteins with experimentally-annotated subcellular
+localizations spanning 10 classes. Train/validation/test splits provided by the SaProtHub
+mirror; structure-aware (SA) sequences are pre-computed from AlphaFold2 predictions.
+</p><div class="meta-row"><strong>Sensitive data:</strong> No human PII; SwissProt protein sequences only</div></div><h3>Training procedure</h3><p>LoRA fine-tuning of SaProt_650M_AF2 on the DeepLoc subcellular-localization train split,
+with the classifier head trained from scratch. Mixed precision (FP16) on a single GPU.
+</p><dl class="kv"><div><dt><code>optimizer</code></dt><dd>AdamW</dd></div><div><dt><code>learning_rate</code></dt><dd><code>0.0005</code></dd></div><div><dt><code>batch_size</code></dt><dd><code>64</code></dd></div><div><dt><code>training_epochs</code></dt><dd><code>100</code></dd></div><div><dt><code>loss_function</code></dt><dd>Cross-entropy over 10 classes</dd></div><div><dt><code>optimization_techniques</code></dt><dd><div class="chip-row"><span class="chip">LoRA rank=16</span> <span class="chip">LoRA alpha=32</span> <span class="chip">LoRA dropout=0</span> <span class="chip">Mixed precision FP16</span> <span class="chip">AdamW betas=(0.9, 0.98)</span> <span class="chip">weight_decay=0.01</span></div></dd></div></dl></section><section class="card"><h2>Quantitative Analysis</h2><table class="metrics"><thead><tr><th>Metric</th><th>Slice</th><th class="num">Value</th><th class="num">Unit</th><th class="num">CI</th></tr></thead><tbody><tr><td>test accuracy</td><td>DeepLoc subcellular localization test set (10-way)</td><td class="num">85.75</td><td class="num">%</td><td class="num"></td></tr></tbody></table></section><section class="card"><h2>Considerations</h2><h3>Intended users</h3><ul class="bullet"><li><strong>Structural biologists and bioinformaticians who want quick subcellular localization
+predictions for protein sequences with known or predicted structure; researchers
+building protein-annotation pipelines.
+</strong></li></ul><h3>Use cases</h3><ul class="bullet"><li><strong>Predicting subcellular localization for protein-annotation pipelines</strong></li><li><strong>Filtering proteomics candidates by compartment of interest</strong></li><li><strong>Benchmarking against DeepLoc 2.0 on the same 10-class taxonomy</strong></li><li><strong>Educational reference for LoRA fine-tuning of protein language models</strong></li></ul><h3>Limitations</h3><ul class="bullet"><li><strong>Trained on SwissProt-curated proteins with experimentally-validated subcellular labels;
+coverage of organism diversity is uneven (heavily human / E. coli / yeast biased).
+</strong></li><li><strong>Requires structure-aware input — sequences without AlphaFold2 structural tokens cannot
+be scored directly. Predictions for novel proteins without structural neighbors may be
+unreliable.
+</strong></li><li><strong>10-way classification only; many proteins localize to multiple compartments. The model
+cannot express multi-label outputs without retraining with a multi-label objective.
+</strong></li></ul><h3>Tradeoffs</h3><ul class="bullet"><li><strong>650M-parameter base provides higher accuracy than the 35M variant (85.75% vs ~80%) at
+higher inference cost. LoRA keeps trainable parameter count small (~few M) but base
+weights still need to be loaded.
+</strong></li></ul><h3>Ethical considerations</h3><ul class="bullet"><li><strong>Mis-localization in drug discovery pipelines</strong><br><em>Mitigation:</em> Treat predictions as a screening hypothesis, not ground truth. Confirm with experimental
+localization (immunofluorescence, fractionation, etc.) before acting on a prediction in
+downstream pharmacology or therapeutic targeting.
+</li></ul><h3>Out-of-scope uses</h3><ul class="bullet"><li><strong>Diagnosing localization-related diseases without experimental confirmation</strong></li><li><strong>Predicting localization in species or kingdoms underrepresented in DeepLoc</strong></li><li><strong>Multi-label localization prediction (model is single-label)</strong></li></ul></section><section class="card"><h2>Bias Disclosure</h2><div class="bias-block"><strong>bias_model:</strong> Predictions reflect the species and protein-family distribution of the DeepLoc training set
+(SwissProt-biased toward extensively-studied model organisms). Performance on understudied
+proteomes and disordered / signal-peptide-containing proteins is not characterized.
+</div><div class="bias-block"><strong>bias_output:</strong> Class prior matches the DeepLoc training distribution — rare compartments (peroxisome,
+plastid) are likely under-predicted relative to their true biological frequency.
+</div></section></main><footer>Rendered 2026-06-24T19:47:30.405623+00:00 from <code>data/model_cards_assistant/subcell_saprot_650m_model_card.yaml</code></footer></body></html>

--- a/src/html/human_readable_renderer.py
+++ b/src/html/human_readable_renderer.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""
+Render a Model Card YAML to a self-contained human-readable HTML page.
+
+Writes the HTML next to the input YAML by default — so
+``data/model_cards_assistant/foo_model_card.yaml`` produces
+``data/model_cards_assistant/foo_model_card.html``.
+
+Usage:
+    poetry run python src/html/human_readable_renderer.py path/to/card.yaml
+    poetry run python src/html/human_readable_renderer.py card.yaml --output custom.html
+    poetry run python src/html/human_readable_renderer.py 'data/model_cards_assistant/*.yaml'
+
+The renderer walks the Model Card structure heuristically — it doesn't require
+the LinkML schema to be loaded. It renders the well-known sections
+(model_details, model_parameters, quantitative_analysis, considerations, etc.)
+into themed cards, then falls through to a generic key/value table for any
+remaining keys. Inline CSS only; no external assets.
+
+If a sibling badge SVG exists under ``data/evaluation/badges/<stem>_*.svg`` it
+is embedded under the title.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import html
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Styling
+# ---------------------------------------------------------------------------
+CSS = """
+:root {
+  --bg: #fafafa; --card: #fff; --border: #e5e5e5;
+  --text: #111; --muted: #6b7280; --accent: #2563eb;
+  --good: #16a34a; --warn: #ca8a04; --bad: #dc2626;
+}
+* { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg); color: var(--text);
+  margin: 0; padding: 2rem 1.5rem; line-height: 1.5;
+}
+header, main, footer { max-width: 980px; margin: 0 auto; }
+header { padding-bottom: 1.25rem; border-bottom: 1px solid var(--border); margin-bottom: 1.5rem; }
+h1 { font-size: 1.85rem; margin: 0 0 .35rem; }
+h2 {
+  font-size: 1.2rem; margin: 1.5rem 0 .6rem;
+  padding-bottom: .3rem; border-bottom: 1px solid var(--border);
+}
+h3 { font-size: 1rem; margin: 1rem 0 .35rem; color: var(--accent); }
+.short { color: var(--muted); font-size: 1rem; margin: 0 0 .75rem; }
+.meta-row { color: var(--muted); font-size: .85rem; }
+.meta-row span + span::before { content: " · "; padding: 0 .2rem; }
+.badge-row { margin: .75rem 0; display: flex; flex-wrap: wrap; gap: .3rem; }
+.badge-row img { height: 20px; }
+
+.card {
+  background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+  padding: 1rem 1.25rem; margin: 1rem 0;
+}
+.card h2 { margin-top: 0; border-bottom: none; }
+
+dl.kv { margin: 0; }
+dl.kv > div { display: grid; grid-template-columns: 200px 1fr; gap: .5rem 1rem; padding: .35rem 0; border-top: 1px solid var(--border); }
+dl.kv > div:first-child { border-top: 0; }
+dl.kv dt { color: var(--muted); font-weight: 500; font-size: .9rem; }
+dl.kv dd { margin: 0; word-break: break-word; }
+dl.kv code { background: #f3f4f6; padding: .05rem .3rem; border-radius: 3px; font-size: .85rem; }
+
+.chip-row { display: flex; flex-wrap: wrap; gap: .35rem; }
+.chip { background: #eef2ff; color: #3730a3; padding: .15rem .55rem; border-radius: 999px; font-size: .8rem; }
+
+ul.bullet { padding-left: 1.2rem; margin: .3rem 0; }
+ul.bullet li { margin: .2rem 0; }
+
+.contrib-row { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem 1rem; padding: .35rem 0; border-top: 1px solid var(--border); font-size: .9rem; }
+.contrib-row:first-child { border-top: 0; }
+.contrib-role { display: inline-block; background: #fef3c7; color: #92400e; padding: .05rem .4rem; border-radius: 4px; font-size: .75rem; margin-left: .35rem; }
+
+table.metrics { width: 100%; border-collapse: collapse; margin: .3rem 0; font-size: .9rem; }
+table.metrics th, table.metrics td {
+  padding: .4rem .75rem; border-top: 1px solid var(--border); text-align: left; vertical-align: top;
+}
+table.metrics th { background: #f9fafb; font-weight: 600; }
+table.metrics td.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+pre {
+  background: #f3f4f6; padding: .75rem 1rem; border-radius: 6px;
+  overflow-x: auto; font-size: .85rem;
+}
+pre code { background: transparent; padding: 0; }
+
+.markdown p { margin: .4rem 0; }
+.markdown code { background: #f3f4f6; padding: .05rem .3rem; border-radius: 3px; font-size: .9rem; }
+
+footer { color: var(--muted); font-size: .8rem; text-align: center; margin: 2rem 0 0; }
+.tag-license { background: #d1fae5; color: #065f46; padding: .1rem .45rem; border-radius: 4px; font-size: .8rem; }
+.bias-block { background: #fff7ed; border-left: 3px solid #f97316; padding: .5rem .75rem; margin: .35rem 0; border-radius: 0 4px 4px 0; font-size: .9rem; }
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def esc(s: Any) -> str:
+    if s is None:
+        return ""
+    return html.escape(str(s))
+
+
+def fmt_inline(value: Any) -> str:
+    """Render a scalar or simple value as an inline HTML snippet."""
+    if value is None:
+        return "<em>—</em>"
+    if isinstance(value, bool):
+        return f'<code>{value}</code>'
+    if isinstance(value, (int, float)):
+        return f'<code>{value}</code>'
+    if isinstance(value, str):
+        if value.startswith(("http://", "https://")):
+            return f'<a href="{esc(value)}">{esc(value)}</a>'
+        if "\n" in value:
+            return f'<pre>{esc(value)}</pre>'
+        return esc(value)
+    if isinstance(value, list):
+        if all(isinstance(v, (str, int, float, bool)) for v in value):
+            chips = " ".join(
+                f'<span class="chip">{esc(v)}</span>' for v in value
+            )
+            return f'<div class="chip-row">{chips}</div>'
+        items = "".join(f"<li>{fmt_inline(v)}</li>" for v in value)
+        return f'<ul class="bullet">{items}</ul>'
+    if isinstance(value, dict):
+        return render_kv_table(value)
+    return esc(value)
+
+
+def render_kv_table(d: dict[str, Any], skip: set[str] | None = None) -> str:
+    if skip is None:
+        skip = set()
+    rows = []
+    for k, v in d.items():
+        if k in skip:
+            continue
+        rows.append(
+            f'<div><dt>{esc(k)}</dt><dd>{fmt_inline(v)}</dd></div>'
+        )
+    if not rows:
+        return ""
+    return f'<dl class="kv">{"".join(rows)}</dl>'
+
+
+def section(title: str, body_html: str) -> str:
+    if not body_html.strip():
+        return ""
+    return f'<section class="card"><h2>{esc(title)}</h2>{body_html}</section>'
+
+
+# ---------------------------------------------------------------------------
+# Section renderers
+# ---------------------------------------------------------------------------
+def render_model_details(md: dict) -> str:
+    if not isinstance(md, dict):
+        return ""
+    parts = []
+    # version + license inline header
+    version = md.get("version") or {}
+    if isinstance(version, dict):
+        v_name = version.get("name", "")
+        v_date = version.get("date", "")
+        v_diff = version.get("diff", "")
+        if v_name or v_date:
+            label = f"<strong>{esc(v_name)}</strong>"
+            if v_date:
+                label += f' <span class="meta-row">{esc(v_date)}</span>'
+            parts.append(f"<p>{label}</p>")
+        if v_diff:
+            parts.append(f'<h3>Change description</h3><div class="markdown"><p>{esc(v_diff)}</p></div>')
+
+    if md.get("overview"):
+        parts.append(f'<h3>Overview</h3><div class="markdown"><p>{esc(md["overview"]).replace(chr(10), "<br>")}</p></div>')
+    if md.get("documentation"):
+        doc = md["documentation"]
+        parts.append(f'<h3>Documentation</h3><pre>{esc(doc)}</pre>')
+
+    # owners + contributors
+    owners = md.get("owners") or []
+    contributors = md.get("contributors") or []
+    if owners or contributors:
+        parts.append("<h3>Owners / Contributors</h3>")
+        rows = []
+        for o in (owners or []):
+            if not isinstance(o, dict):
+                continue
+            rows.append(
+                f'<div class="contrib-row">'
+                f'<span><strong>{esc(o.get("name", ""))}</strong>'
+                f'{f"<span class=contrib-role>owner</span>" if o.get("name") else ""}</span>'
+                f'<span>{esc(o.get("contact", ""))} {esc(o.get("affiliation", ""))}</span>'
+                f'</div>'
+            )
+        for c in (contributors or []):
+            if not isinstance(c, dict):
+                continue
+            role = c.get("role", "")
+            role_html = f' <span class="contrib-role">{esc(role)}</span>' if role else ""
+            extra = " · ".join(
+                esc(c[k]) for k in ("email", "orcid", "affiliation") if c.get(k)
+            )
+            rows.append(
+                f'<div class="contrib-row">'
+                f'<span><strong>{esc(c.get("name", ""))}</strong>{role_html}</span>'
+                f'<span>{extra}</span>'
+                f'</div>'
+            )
+        parts.append("".join(rows))
+
+    # licenses
+    licenses = md.get("licenses") or []
+    if licenses:
+        parts.append("<h3>Licenses</h3>")
+        chips = []
+        for lic in licenses:
+            if isinstance(lic, dict):
+                ident = lic.get("identifier", "")
+                link = lic.get("license_link") or ""
+                label = esc(ident)
+                if link:
+                    label = f'<a href="{esc(link)}">{label}</a>'
+                chips.append(f'<span class="tag-license">{label}</span>')
+            else:
+                chips.append(f'<span class="tag-license">{esc(lic)}</span>')
+        parts.append(f'<div class="chip-row">{" ".join(chips)}</div>')
+
+    # citations
+    citations = md.get("citations") or []
+    if citations:
+        parts.append("<h3>Citations</h3>")
+        for c in citations:
+            if isinstance(c, dict):
+                style = c.get("style", "")
+                cite = c.get("citation", "")
+                parts.append(
+                    f'<p><span class="chip">{esc(style)}</span> '
+                    f'<span class="markdown">{esc(cite)}</span></p>'
+                )
+
+    # references
+    refs = md.get("references") or []
+    if refs:
+        parts.append("<h3>References</h3>")
+        items = []
+        for r in refs:
+            if isinstance(r, dict):
+                items.append(f'<li>{fmt_inline(r.get("reference"))}</li>')
+            else:
+                items.append(f"<li>{fmt_inline(r)}</li>")
+        parts.append(f'<ul class="bullet">{"".join(items)}</ul>')
+
+    # path
+    if md.get("path"):
+        parts.append(f'<h3>Path</h3>{fmt_inline(md["path"])}')
+
+    return "".join(parts)
+
+
+def render_model_parameters(mp: dict) -> str:
+    if not isinstance(mp, dict):
+        return ""
+    parts = []
+    if mp.get("model_architecture"):
+        parts.append(
+            f'<h3>Architecture</h3>'
+            f'<div class="markdown"><p>{esc(mp["model_architecture"]).replace(chr(10), "<br>")}</p></div>'
+        )
+
+    for io_key, io_map_key, label in (
+        ("input_format", "input_format_map", "Input"),
+        ("output_format", "output_format_map", "Output"),
+    ):
+        io = mp.get(io_key)
+        io_map = mp.get(io_map_key) or []
+        if io or io_map:
+            parts.append(f'<h3>{label} format</h3>')
+            if io:
+                parts.append(f'<p>{esc(io)}</p>')
+            if io_map:
+                rows = []
+                for kv in io_map:
+                    if isinstance(kv, dict):
+                        rows.append(
+                            f'<div><dt><code>{esc(kv.get("key", ""))}</code></dt>'
+                            f'<dd>{fmt_inline(kv.get("value"))}</dd></div>'
+                        )
+                if rows:
+                    parts.append(f'<dl class="kv">{"".join(rows)}</dl>')
+
+    # data (training/eval datasets)
+    data = mp.get("data") or []
+    if data:
+        parts.append("<h3>Datasets</h3>")
+        for ds in data:
+            if isinstance(ds, dict):
+                name = esc(ds.get("name", ""))
+                link = ds.get("link") or ""
+                title = f'<a href="{esc(link)}">{name}</a>' if link else name
+                desc = ds.get("description") or ""
+                bias_input = ds.get("bias_input") or ""
+                sensitive = (ds.get("sensitive") or {}).get("sensitive_data") or []
+                inner = []
+                if desc:
+                    inner.append(f"<p>{esc(desc)}</p>")
+                if sensitive:
+                    sens_str = ", ".join(esc(s) for s in sensitive) if isinstance(sensitive, list) else esc(sensitive)
+                    inner.append(f'<div class="meta-row"><strong>Sensitive data:</strong> {sens_str}</div>')
+                if bias_input:
+                    inner.append(f'<div class="bias-block"><strong>bias_input:</strong> {esc(bias_input)}</div>')
+                parts.append(f'<div style="margin-bottom: .5rem;"><strong>{title}</strong>{"".join(inner)}</div>')
+
+    # training procedure
+    tp = mp.get("training_procedure")
+    if isinstance(tp, dict):
+        parts.append("<h3>Training procedure</h3>")
+        if tp.get("description"):
+            parts.append(f'<p>{esc(tp["description"])}</p>')
+        hp_block = tp.get("reproducibility_info", {}).get("hyperparameters") if isinstance(tp.get("reproducibility_info"), dict) else None
+        if not hp_block:
+            hp_block = tp.get("hyperparameters")
+        if isinstance(hp_block, dict):
+            rows = []
+            for k, v in hp_block.items():
+                rows.append(f'<div><dt><code>{esc(k)}</code></dt><dd>{fmt_inline(v)}</dd></div>')
+            parts.append(f'<dl class="kv">{"".join(rows)}</dl>')
+
+    # compute infrastructure
+    ci = mp.get("compute_infrastructure")
+    if isinstance(ci, dict) and ci:
+        parts.append("<h3>Compute infrastructure</h3>")
+        parts.append(render_kv_table(ci))
+
+    return "".join(parts)
+
+
+def render_quantitative_analysis(qa: dict) -> str:
+    if not isinstance(qa, dict):
+        return ""
+    metrics = qa.get("performance_metrics") or []
+    if not metrics:
+        return ""
+    parts = ['<table class="metrics"><thead><tr>'
+             '<th>Metric</th><th>Slice</th><th class="num">Value</th><th class="num">Unit</th>'
+             '<th class="num">CI</th></tr></thead><tbody>']
+    for m in metrics:
+        if not isinstance(m, dict):
+            continue
+        t = esc(m.get("type", ""))
+        slc = esc(m.get("slice", ""))
+        val = m.get("value", "")
+        unit = esc(m.get("unit", ""))
+        ci_obj = m.get("confidence_interval") or {}
+        ci_txt = ""
+        if isinstance(ci_obj, dict) and ci_obj:
+            lo, hi = ci_obj.get("lower_bound"), ci_obj.get("upper_bound")
+            if lo is not None and hi is not None:
+                ci_txt = f"[{lo} – {hi}]"
+        elif m.get("value_error") is not None:
+            ci_txt = f"± {m['value_error']}"
+        parts.append(
+            f'<tr><td>{t}</td><td>{slc}</td>'
+            f'<td class="num">{esc(val)}</td><td class="num">{unit}</td>'
+            f'<td class="num">{esc(ci_txt)}</td></tr>'
+        )
+    parts.append("</tbody></table>")
+    return "".join(parts)
+
+
+def render_considerations(c: dict) -> str:
+    if not isinstance(c, dict):
+        return ""
+    blocks = []
+    for key, label in (
+        ("users", "Intended users"),
+        ("use_cases", "Use cases"),
+        ("limitations", "Limitations"),
+        ("tradeoffs", "Tradeoffs"),
+        ("ethical_considerations", "Ethical considerations"),
+        ("out_of_scope_uses", "Out-of-scope uses"),
+    ):
+        items = c.get(key) or []
+        if not items:
+            continue
+        blocks.append(f"<h3>{label}</h3>")
+        bullets = []
+        for it in items:
+            if isinstance(it, dict):
+                title = it.get("name") or it.get("description") or ""
+                desc = it.get("description") if it.get("name") else ""
+                mit = it.get("mitigation_strategy") or ""
+                line = f"<strong>{esc(title)}</strong>"
+                if desc and desc != title:
+                    line += f"<br><span class='markdown'>{esc(desc)}</span>"
+                if mit:
+                    line += f"<br><em>Mitigation:</em> {esc(mit)}"
+                bullets.append(f"<li>{line}</li>")
+            else:
+                bullets.append(f"<li>{esc(it)}</li>")
+        blocks.append(f'<ul class="bullet">{"".join(bullets)}</ul>')
+    return "".join(blocks)
+
+
+def render_bias(card: dict) -> str:
+    rows = []
+    for key in ("bias_model", "bias_output"):
+        v = card.get(key)
+        if v:
+            rows.append(f'<div class="bias-block"><strong>{key}:</strong> {esc(v)}</div>')
+    return "".join(rows)
+
+
+# ---------------------------------------------------------------------------
+# Top-level render
+# ---------------------------------------------------------------------------
+KNOWN_TOPLEVEL = {
+    "schema_version", "model_details", "model_parameters", "quantitative_analysis",
+    "considerations", "model_category", "bias_model", "bias_output", "framework",
+    "framework_version", "library_name", "pipeline_tag", "language", "base_model",
+    "tags", "datasets", "metrics", "model_index", "mission_relevance",
+    "usage_documentation",
+}
+
+
+def find_badge_files(yaml_path: Path) -> list[Path]:
+    badge_dir = Path("data/evaluation/badges")
+    if not badge_dir.is_dir():
+        return []
+    stem = yaml_path.stem
+    return sorted(badge_dir.glob(f"{stem}_rubric*_*.svg"))
+
+
+def render_card(yaml_path: Path) -> str:
+    raw = yaml_path.read_text()
+    card = yaml.safe_load(raw)
+    if not isinstance(card, dict):
+        raise SystemExit(f"{yaml_path}: top-level YAML is not a mapping")
+
+    md = card.get("model_details") or {}
+    name = md.get("name") or yaml_path.stem
+    short = md.get("short_description") or ""
+
+    # meta row
+    meta_pieces = []
+    if card.get("pipeline_tag"):
+        meta_pieces.append(f'<span><code>{esc(card["pipeline_tag"])}</code></span>')
+    if card.get("framework"):
+        fw = card["framework"]
+        if card.get("framework_version"):
+            fw = f"{fw} {card['framework_version']}"
+        meta_pieces.append(f"<span>{esc(fw)}</span>")
+    if card.get("library_name"):
+        meta_pieces.append(f"<span>library: <code>{esc(card['library_name'])}</code></span>")
+    if card.get("base_model"):
+        meta_pieces.append(f"<span>base: <code>{esc(card['base_model'])}</code></span>")
+    meta_row = f'<div class="meta-row">{"".join(meta_pieces)}</div>' if meta_pieces else ""
+
+    # tags chip row
+    tags = card.get("tags") or []
+    tags_row = ""
+    if tags:
+        chips = " ".join(f'<span class="chip">{esc(t)}</span>' for t in tags)
+        tags_row = f'<div class="chip-row" style="margin-top:.4rem;">{chips}</div>'
+
+    # badges
+    badges = find_badge_files(yaml_path)
+    badge_row = ""
+    if badges:
+        imgs = " ".join(
+            f'<img src="../evaluation/badges/{b.name}" alt="{b.stem}">'
+            for b in badges
+        )
+        badge_row = f'<div class="badge-row">{imgs}</div>'
+
+    header = (
+        f'<header>'
+        f'<h1>{esc(name)}</h1>'
+        f'{f"<p class=short>{esc(short)}</p>" if short else ""}'
+        f'{meta_row}'
+        f'{tags_row}'
+        f'{badge_row}'
+        f'<div class="meta-row" style="margin-top:.5rem;">'
+        f'Source YAML: <code>{esc(yaml_path)}</code>'
+        f'</div>'
+        f'</header>'
+    )
+
+    body_parts = []
+    body_parts.append(section("Model Details", render_model_details(md)))
+    body_parts.append(section("Model Parameters", render_model_parameters(card.get("model_parameters") or {})))
+    body_parts.append(section("Quantitative Analysis", render_quantitative_analysis(card.get("quantitative_analysis") or {})))
+    body_parts.append(section("Considerations", render_considerations(card.get("considerations") or {})))
+    body_parts.append(section("Bias Disclosure", render_bias(card)))
+
+    # Anything top-level not consumed above
+    leftovers = {k: v for k, v in card.items() if k not in KNOWN_TOPLEVEL}
+    if leftovers:
+        body_parts.append(section("Other fields", render_kv_table(leftovers)))
+
+    body = "".join(p for p in body_parts if p)
+
+    return (
+        '<!doctype html><html><head>'
+        '<meta charset="utf-8">'
+        f'<title>{esc(name)} — Model Card</title>'
+        f'<style>{CSS}</style>'
+        '</head><body>'
+        + header
+        + f'<main>{body}</main>'
+        f'<footer>Rendered {datetime.now(timezone.utc).isoformat()} from '
+        f'<code>{esc(yaml_path)}</code></footer>'
+        '</body></html>'
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("input", nargs="+", help="Model Card YAML file(s) or glob(s)")
+    p.add_argument("--output", type=Path, default=None,
+                   help="Output HTML path (only valid for a single input)")
+    args = p.parse_args(argv)
+
+    paths: list[Path] = []
+    for entry in args.input:
+        ps = sorted(Path(p) for p in glob.glob(entry))
+        if not ps and Path(entry).exists():
+            ps = [Path(entry)]
+        paths.extend(ps)
+
+    if not paths:
+        print("No matching input files.", file=sys.stderr)
+        return 1
+    if args.output and len(paths) > 1:
+        print("--output is only valid with a single input", file=sys.stderr)
+        return 2
+
+    for yaml_path in paths:
+        html_doc = render_card(yaml_path)
+        out = args.output or yaml_path.with_suffix(".html")
+        out.write_text(html_doc)
+        print(f"{yaml_path} → {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements `src/html/human_readable_renderer.py` — the script that `@mcassistant` workflow docs (mc_assistant_create.md step 8, mc_assistant_edit.md step 7) reference but that never existed.

Closes PR #25 review finding #4.

## Rendered cards (in this PR)

- [`data/model_cards_assistant/densenet121_tv_in1k_model_card.html`](data/model_cards_assistant/densenet121_tv_in1k_model_card.html)
- [`data/model_cards_assistant/subcell_saprot_650m_model_card.html`](data/model_cards_assistant/subcell_saprot_650m_model_card.html)

Both render 5 sections (Model Details / Parameters / Quantitative Analysis / Considerations / Bias Disclosure) and all 6 quality badges (rubric10/rubric20 × hybrid/LLM/semantic) inline.

## Features
- Self-contained HTML (inline CSS, no external assets)
- Themed sections with auto-detection of populated fields
- Embeds quality badges from `data/evaluation/badges/<stem>_*.svg`
- Falls through to a generic key/value table for any unmodeled top-level fields
- Glob-friendly: `make render-card MC_FILE='data/model_cards_assistant/*.yaml'`

## Makefile
New `render-card` target: `make render-card MC_FILE=path/to/card.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)